### PR TITLE
Fix expect exit status by not returning from eof

### DIFF
--- a/automount.sh
+++ b/automount.sh
@@ -657,9 +657,7 @@ function processMountlist {
 							timeout {
 								exit 1
 							}
-							eof {
-								return
-							}
+							eof
 						}
 						catch wait result
 						exit [lindex $result 3]
@@ -684,9 +682,7 @@ function processMountlist {
 								send -- "'$(getPasswordFromKeychain | convertToHexCode)'\r"
 								exp_continue
 							}
-							eof {
-								return
-							}
+							eof
 							timeout {
 								exit 1
 							}
@@ -728,9 +724,7 @@ function processMountlist {
 							timeout {
 								exit 1
 							}
-							eof {
-								return
-							}
+							eof
 						}
 						catch wait result
 						exit [lindex $result 3]' 2>&1)"
@@ -761,9 +755,7 @@ function processMountlist {
 							timeout {
 								exit 1
 							}
-							eof {
-								return
-							}
+							eof
 						}
 						catch wait result
 						exit [lindex $result 3]' 2>&1)"
@@ -786,9 +778,7 @@ function processMountlist {
 							timeout {
 								exit 1
 							}
-							eof {
-								return
-							}
+							eof
 						}
 						catch wait result
 						exit [lindex $result 3]' 2>&1)"


### PR DESCRIPTION
The "eof { return }" statement caused the exit status from the mount
application to be always set to zero. By replacing this with a simple "eof"
statement, the exit status is properly propagated.