### PR TITLE
Fix hexadecimal conversion of e.g. passwords

### DIFF
--- a/automount.sh
+++ b/automount.sh
@@ -446,9 +446,9 @@ function getKeychainProtocol {
 }
 
 function convertToHexCode {
-    tr -d '\n' |\
-    od -A n -t x1 |\
-    sed -E 's/^ */  /;s/ *$//;s/  /\\x/g'
+    tr -d '\n' \
+        | xxd -pu \
+        | sed -E 's/(.{2})/\\x\1/g'
 }
 
 function getPasswordFromKeychain {


### PR DESCRIPTION
The od / sed / sed pipeline caused longer passwords to be wrapped causing the
mount tools to trip over password entry, resulting in authentication failures.
This much simpler approach using `hexdump` correctly converts all input bytes
into the format `expect` expects when entering the password.